### PR TITLE
Fix unexpected ADC behavior due to uninitialized data being sent over SPI

### DIFF
--- a/src/MCP3x6x.cpp
+++ b/src/MCP3x6x.cpp
@@ -124,6 +124,7 @@ MCP3x6x::status_t MCP3x6x::read(Adcdata *data) {
     }
   */
   uint8_t buffer[s];
+  memset(buffer, 0, s);
 
   //  while (status_dr()) {
   _transfer(buffer, MCP3x6x_CMD_SREAD | MCP3x6x_ADR_ADCDATA, s);


### PR DESCRIPTION
Zero-initialize the buffer used for ADC reads, as the buffer is always written over the wire as part of the SPI transaction. In unlucky circumstances the uninitialized buffer would encode a valid command, resetting the device or triggering other undesired behavior.

Note that `uint8_t buffer[s] = {0};` won't work due to the variable-length of the array.